### PR TITLE
(bugfix) Workarounds to allow component to work on Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "homepage": "https://github.com/wwdrew/react-native-numeric-textinput#readme",
   "dependencies": {
-    "currency-codes": "^1.5.0"
+    "currency-codes": "^1.5.0",
+    "intl": "^1.2.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.3",

--- a/src/NumericTextInput.js
+++ b/src/NumericTextInput.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import { TextInput } from 'react-native';
+import { Platform, TextInput } from 'react-native';
 import { code } from 'currency-codes';
 
 // Polyfill for Intl until properly supported in Android
@@ -110,7 +110,7 @@ const NumericTextInput = ({
       {...textInputProps}
       onKeyPress={({ nativeEvent: { key } }: KeyPressEvent) => updateValue(key, onUpdate)}
       value={formatValue(value)}
-      keyboardType="number-pad"
+      keyboardType={Platform.OS === 'ios' ? 'number-pad' : 'default'} // Another temporary fix for Android as the numeric keyboards don't fire keyPress events
     />
   );
 };

--- a/src/NumericTextInput.js
+++ b/src/NumericTextInput.js
@@ -4,6 +4,10 @@ import React from 'react';
 import { TextInput } from 'react-native';
 import { code } from 'currency-codes';
 
+// Polyfill for Intl until properly supported in Android
+import 'intl';
+import 'intl/locale-data/jsonp/en';
+
 import type { KeyPressEvent } from 'TextInput';
 
 type NumericTextInputType = 'currency' | 'decimal'


### PR DESCRIPTION
https://github.com/wwdrew/react-native-numeric-textinput/issues/1

Revisit these when/if these issues are ever fixed.